### PR TITLE
New tests, generic request generator and support for deleting the created instances

### DIFF
--- a/src/main/java/com/example/teamcity/api/generators/TestData.java
+++ b/src/main/java/com/example/teamcity/api/generators/TestData.java
@@ -20,8 +20,19 @@ public class TestData {
     private BuildType buildType;
 
     public void delete(){
-        var spec = Specifications.getSpec().getAuthenticatedSpec(user);
-        new UncheckedProjectRequest(spec).delete(project.getId());
-        new UncheckedUserRequest(spec).delete(user.getUsername());
+        var spec = Specifications.getSpec().getSuperUserSpec();
+        if (TestDataCleanUp.getTestDataUsed().toString().contains("project")) {
+            new UncheckedProjectRequest(spec).delete(project.getId());
+        }
+        if (TestDataCleanUp.getTestDataUsed().toString().contains("user")) {
+            new UncheckedUserRequest(spec).delete(user.getUsername());
+        }
     }
+
+//    public void delete(){
+//        var spec = Specifications.getSpec().getSuperUserSpec();
+//       // var spec = Specifications.getSpec().getAuthenticatedSpec(user);
+//        new UncheckedProjectRequest(spec).delete(project.getId());
+//        new UncheckedUserRequest(spec).delete(user.getUsername());
+//    }
 }

--- a/src/main/java/com/example/teamcity/api/generators/TestDataCleanUp.java
+++ b/src/main/java/com/example/teamcity/api/generators/TestDataCleanUp.java
@@ -1,0 +1,19 @@
+package com.example.teamcity.api.generators;
+
+import java.util.ArrayList;
+
+public class TestDataCleanUp {
+    private static ArrayList<String> testDataUsed = new ArrayList<>();
+
+    public static ArrayList<String> getTestDataUsed(){
+        return testDataUsed;
+    }
+
+    public boolean contains(String element) {
+        return testDataUsed.contains(element);
+    }
+
+    public void clear() {
+        testDataUsed.clear();
+    }
+}

--- a/src/main/java/com/example/teamcity/api/generators/TestDataGenerator.java
+++ b/src/main/java/com/example/teamcity/api/generators/TestDataGenerator.java
@@ -18,7 +18,7 @@ public class TestDataGenerator {
 
     public static ServerAuthSettings generateServerAuthSettings() {
         return new ServerAuthSettings().builder()
-                .perProjectPermissions(false)
+                .perProjectPermissions(true)
                 .modules(AuthModules.builder()
                         .module(Arrays.asList(
                                 AuthModule.builder()
@@ -67,7 +67,7 @@ public class TestDataGenerator {
 
     public static TestData generate(){
         var user = User.builder()
-                .username(RandomData.getString())
+                .username("user_" + RandomData.getString())
                 .password(RandomData.getString())
                 .email(RandomData.getString() + "@gmail.com")
                 .roles(Roles.builder()
@@ -84,7 +84,7 @@ public class TestDataGenerator {
                         .locator("_Root")
                         .build())
                 .name(RandomData.getString())
-                .id(RandomData.getString())
+                .id("project_" + RandomData.getString())
                 .copyAllAssociatedSettings(true)
                 .build();
 

--- a/src/main/java/com/example/teamcity/api/requests/checked/CheckedRequestGenerator.java
+++ b/src/main/java/com/example/teamcity/api/requests/checked/CheckedRequestGenerator.java
@@ -1,0 +1,44 @@
+package com.example.teamcity.api.requests.checked;
+
+import com.example.teamcity.api.requests.CrudInterface;
+import com.example.teamcity.api.requests.Request;
+import com.example.teamcity.api.requests.unchecked.UncheckedRequestGenerator;
+import io.restassured.specification.RequestSpecification;
+import org.apache.http.HttpStatus;
+
+import java.lang.reflect.Type;
+
+public class CheckedRequestGenerator<Response> extends Request implements CrudInterface {
+    private Class<Request> requestClass;
+    private final Class<Response> responseClass;
+
+    public CheckedRequestGenerator(RequestSpecification spec, Class requestClass, Class responseClass) {
+        super(spec);
+        this.requestClass = requestClass;
+        this.responseClass = responseClass;
+    }
+
+    @Override
+    public Response create(Object obj) {
+        return new UncheckedRequestGenerator<Type>(spec, requestClass).create(obj)
+                .then().assertThat().statusCode(HttpStatus.SC_OK)
+                .extract().as(responseClass);
+    }
+
+    @Override
+    public Object get(String id) {
+        return null;
+    }
+
+    @Override
+    public Object update(String id, Object obj) {
+        return null;
+    }
+
+    @Override
+    public Object delete(String id) {
+        return new UncheckedRequestGenerator<Type>(spec,requestClass).delete(id)
+                .then().assertThat().statusCode(HttpStatus.SC_NO_CONTENT)
+                .extract().asString();
+    }
+}

--- a/src/main/java/com/example/teamcity/api/requests/unchecked/UncheckedProjectRequest.java
+++ b/src/main/java/com/example/teamcity/api/requests/unchecked/UncheckedProjectRequest.java
@@ -31,7 +31,7 @@ public class UncheckedProjectRequest extends Request implements CrudInterface {
     }
 
     @Override
-    public Object update(String id, Object objj) {
+    public Object update(String id, Object obj) {
         return null;
     }
 

--- a/src/main/java/com/example/teamcity/api/requests/unchecked/UncheckedRequestGenerator.java
+++ b/src/main/java/com/example/teamcity/api/requests/unchecked/UncheckedRequestGenerator.java
@@ -1,0 +1,67 @@
+package com.example.teamcity.api.requests.unchecked;
+
+import com.example.teamcity.api.generators.TestDataCleanUp;
+import com.example.teamcity.api.requests.CrudInterface;
+import com.example.teamcity.api.requests.Request;
+import io.restassured.response.Response;
+import io.restassured.specification.RequestSpecification;
+
+import static io.restassured.RestAssured.given;
+
+public class UncheckedRequestGenerator<T> extends Request implements CrudInterface {
+    private String endpoint;
+    private Class<T> requestClass;
+    private String identifier = "/id:";
+
+    public UncheckedRequestGenerator(RequestSpecification spec, Class requestClass) {
+        super(spec);
+        this.requestClass = requestClass;
+
+        switch (requestClass.getSimpleName()) {
+            case "BuildConfigurationTest":
+                endpoint = "/app/rest/buildTypes";
+                break;
+            case "NewProjectDescription":
+                endpoint = "/app/rest/projects";
+                break;
+            case "User":
+                endpoint = "/app/rest/users";
+                identifier = "/username:";
+                break;
+        }
+    }
+
+    @Override
+    public Response create(Object obj) {
+        var response = given()
+                .spec(spec)
+                .body(obj)
+                .post(endpoint);
+        if (response.statusCode() >= 200 && response.statusCode() <= 300){
+            TestDataCleanUp.getTestDataUsed().add(obj.toString());
+        }
+        return response;
+    }
+
+    @Override
+    public Response get(String id) {
+        return given()
+                .spec(spec)
+                .get(endpoint + "/id:" + id);
+    }
+
+    @Override
+    public Object update(String id, Object obj) {
+        return given()
+                .spec(spec)
+                .body(obj)
+                .put(endpoint + "/id:" + id);
+    }
+
+    @Override
+    public Response delete(String id) {
+        return given()
+                .spec(spec)
+                .delete(endpoint + identifier + id);
+    }
+}

--- a/src/test/java/com/example/teamcity/api/BaseApiTest.java
+++ b/src/test/java/com/example/teamcity/api/BaseApiTest.java
@@ -1,16 +1,24 @@
 package com.example.teamcity.api;
 
+import com.example.teamcity.api.generators.TestDataCleanUp;
 import com.example.teamcity.api.generators.TestDataStorage;
 import com.example.teamcity.api.requests.checked.CheckedRequests;
 import com.example.teamcity.api.requests.unchecked.UncheckedRequests;
 import com.example.teamcity.api.spec.Specifications;
+import io.restassured.specification.RequestSpecification;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeSuite;
 
+import java.util.ArrayList;
+
 public class BaseApiTest extends BaseTest{
 
     public TestDataStorage testDataStorage;
+    public ArrayList<String> testDataCleanUp;
+
+    public RequestSpecification superUserSpec = Specifications.getSpec().getSuperUserSpec();
+    public RequestSpecification unauthUserSpec = Specifications.getSpec().getUnauthenticatedSpec();
 
     public CheckedRequests checkedWithSuperUser
             = new CheckedRequests(Specifications.getSpec().getSuperUserSpec());
@@ -24,8 +32,9 @@ public class BaseApiTest extends BaseTest{
     }
 
     @BeforeMethod
-    public void setupTest(){
+    public void setupTest() {
         testDataStorage = TestDataStorage.getStorage();
+        testDataCleanUp = TestDataCleanUp.getTestDataUsed();
     }
 
     @AfterTest

--- a/src/test/java/com/example/teamcity/api/BuildConfigurationTest.java
+++ b/src/test/java/com/example/teamcity/api/BuildConfigurationTest.java
@@ -1,8 +1,15 @@
 package com.example.teamcity.api;
 
+import com.example.teamcity.api.models.BuildType;
+import com.example.teamcity.api.models.NewProjectDescription;
+import com.example.teamcity.api.models.Project;
 import com.example.teamcity.api.requests.checked.CheckedProjectRequest;
+import com.example.teamcity.api.requests.checked.CheckedRequestGenerator;
 import com.example.teamcity.api.requests.checked.CheckedUserRequest;
+import com.example.teamcity.api.requests.unchecked.UncheckedRequestGenerator;
 import com.example.teamcity.api.spec.Specifications;
+import org.apache.http.HttpStatus;
+import org.hamcrest.Matchers;
 import org.testng.annotations.Test;
 
 public class BuildConfigurationTest extends BaseApiTest{
@@ -18,5 +25,121 @@ public class BuildConfigurationTest extends BaseApiTest{
 
         softly.assertThat(project.getId())
                 .isEqualTo(testData.getProject().getId());
+    }
+
+    //1. create a build with required values provided
+    @Test
+    public void buildConfigShouldGetCreatedWithRequiredValuesProvided(){
+        var testData = testDataStorage.addTestData();
+
+        checkedWithSuperUser.getProjectRequest()
+                .create(testData.getProject());
+        testDataCleanUp.add(testData.getProject().getId());
+
+        var buildConfig = checkedWithSuperUser.getBuildConfigRequest()
+                .create(testData.getBuildType());
+
+        softly.assertThat(buildConfig.getId())
+                .isEqualTo(testData.getBuildType().getId());
+    }
+
+    //2. try creating a build with Id missing
+    //Example of generic unchecked and checked requests generator
+    @Test
+    public void buildConfigShouldNotGetCreatedHavingBuildIdEmpty(){
+        var testData = testDataStorage.addTestData();
+
+        new CheckedRequestGenerator<Project>(superUserSpec, NewProjectDescription.class, Project.class)
+                .create(testData.getProject());
+
+        testData.getBuildType().setId("");
+
+        new UncheckedRequestGenerator<BuildType>(superUserSpec, BuildConfigurationTest.class)
+                .create(testData.getBuildType())
+                .then().assertThat()
+                    .statusCode(HttpStatus.SC_BAD_REQUEST)
+                    .body(Matchers.containsString("Build configuration or template ID must not be empty."));
+    }
+
+    //3. try creating a build with Name missing
+    @Test
+    public void buildConfigShouldNotGetCreatedHavingNameEmpty(){
+        var testData = testDataStorage.addTestData();
+
+        checkedWithSuperUser.getProjectRequest()
+                .create(testData.getProject());
+        testDataCleanUp.add(testData.getProject().getId());
+
+        testData.getBuildType().setName("");
+
+        uncheckedWithSuperUser.getBuildConfigRequest()
+                .create(testData.getBuildType())
+                .then().assertThat()
+                .statusCode(HttpStatus.SC_BAD_REQUEST)
+                .body(Matchers.containsString("When creating a build type, non empty name should be provided."));
+    }
+
+    //4. try creating a build reusing an existing Id
+    @Test
+    public void buildConfigShouldNotGetCreatedHavingExistingId(){
+        var firstTestData = testDataStorage.addTestData();
+        var secondTestData = testDataStorage.addTestData();
+
+        checkedWithSuperUser.getProjectRequest()
+                .create(firstTestData.getProject());
+        testDataCleanUp.add(firstTestData.getProject().getId());
+
+        checkedWithSuperUser.getBuildConfigRequest()
+                .create(firstTestData.getBuildType());
+
+        secondTestData.getBuildType().setId(firstTestData.getBuildType().getId());
+        secondTestData.getBuildType().setProject(firstTestData.getProject());
+
+        uncheckedWithSuperUser.getBuildConfigRequest()
+                .create(secondTestData.getBuildType())
+                .then().assertThat()
+                .statusCode(HttpStatus.SC_BAD_REQUEST)
+                .body(Matchers.containsString(
+                        "The build configuration / template ID \"" + firstTestData.getBuildType().getId()
+                                + "\" is already used by another configuration or template"));
+    }
+
+    //5. try creating a build reusing an existing name
+    @Test
+    public void buildConfigShouldNotGetCreatedHavingExistingName(){
+        var firstTestData = testDataStorage.addTestData();
+        var secondTestData = testDataStorage.addTestData();
+
+        checkedWithSuperUser.getProjectRequest()
+                .create(firstTestData.getProject());
+        testDataCleanUp.add(firstTestData.getProject().getId());
+
+        checkedWithSuperUser.getBuildConfigRequest()
+                .create(firstTestData.getBuildType());
+
+        secondTestData.getBuildType().setName(firstTestData.getBuildType().getName());
+        secondTestData.getBuildType().setProject(firstTestData.getProject());
+
+        uncheckedWithSuperUser.getBuildConfigRequest()
+                .create(secondTestData.getBuildType())
+                .then().assertThat()
+                .statusCode(HttpStatus.SC_BAD_REQUEST)
+                .body(Matchers.containsString(
+                        "The build configuration / template ID \"" + firstTestData.getBuildType().getId()
+                                + "\" is already used by another configuration or template"));
+    }
+
+    //6. try creating a build using a not existing project Id
+    @Test
+    public void buildConfigShouldNotGetCreatedHavingProjectNonExistent(){
+        var testData = testDataStorage.addTestData();
+
+        uncheckedWithSuperUser.getBuildConfigRequest()
+                .create(testData.getBuildType())
+                .then().assertThat()
+                .statusCode(HttpStatus.SC_NOT_FOUND)
+                .body(Matchers.containsString(
+                        "Project cannot be found by external id '"
+                                + testData.getBuildType().getProject().getId()));
     }
 }

--- a/src/test/java/com/example/teamcity/api/ProjectTest.java
+++ b/src/test/java/com/example/teamcity/api/ProjectTest.java
@@ -1,0 +1,177 @@
+package com.example.teamcity.api;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.http.HttpStatus;
+import org.hamcrest.Matchers;
+import org.testng.annotations.Test;
+
+public class ProjectTest extends BaseApiTest{
+
+    //1. create project with all required fields under root
+    @Test
+    public void projShouldGetCreatedUnderRootWithRequiredFieldsProvided(){
+        var testData = testDataStorage.addTestData();
+
+        var project = checkedWithSuperUser.getProjectRequest()
+                .create(testData.getProject());
+
+        softly.assertThat(project.getId())
+                .isEqualTo(testData.getProject().getId());
+    }
+
+    //2. create project with required fields under another project
+    @Test
+    public void projShouldGetCreatedUnderAnotherProjWithRequiredFieldsProvided(){
+        var firstTestData = testDataStorage.addTestData();
+        var secondTestData = testDataStorage.addTestData();
+
+        var projectOne = checkedWithSuperUser.getProjectRequest()
+                .create(firstTestData.getProject());
+
+        testDataCleanUp.add(projectOne.getId());
+
+        secondTestData.getProject().setParentProject(projectOne);
+
+        var projectTwo = checkedWithSuperUser.getProjectRequest()
+                .create(secondTestData.getProject());
+
+        softly.assertThat(projectTwo.getId())
+                .isEqualTo(secondTestData.getProject().getId());
+
+        softly.assertThat(projectTwo.getParentProjectId())
+                .isEqualTo(projectOne.getId());
+
+    }
+    //3. create project with all fields provided
+    // TODO
+
+    //4. create project with copySettings = false
+    @Test
+    public void projShouldGetCreatedUnderRootHavingCopyAllAssociatedSettingsSetToFalse(){
+        var testData = testDataStorage.addTestData();
+
+        testData.getProject().setCopyAllAssociatedSettings(false);
+
+        var project = checkedWithSuperUser.getProjectRequest()
+                .create(testData.getProject());
+
+        testDataCleanUp.add(project.getId());
+
+        softly.assertThat(project.getId())
+                .isEqualTo(testData.getProject().getId());
+    }
+
+    //5. create project with missing name
+    @Test
+    public void projShouldNotGetCreatedHavingNameEmpty(){
+        var testData = testDataStorage.addTestData();
+
+        testData.getProject().setName("");
+
+        uncheckedWithSuperUser.getProjectRequest()
+                .create(testData.getProject())
+                .then().assertThat().statusCode(HttpStatus.SC_BAD_REQUEST)
+                .body(Matchers.containsString("Project name cannot be empty."));
+    }
+
+    //6. create project with missing id
+    @Test
+    public void projShouldNotGetCreatedHavingIdEmpty(){
+        var testData = testDataStorage.addTestData();
+
+        testData.getProject().setId("");
+
+        uncheckedWithSuperUser.getProjectRequest()
+                .create(testData.getProject())
+                .then().assertThat().statusCode(HttpStatus.SC_BAD_REQUEST)
+                .body(Matchers.containsString("Project ID must not be empty."));
+    }
+
+    //7. create project with non existent parent
+    @Test
+    public void projShouldNotGetCreatedHavingNonExistentParent(){
+        var firstTestData = testDataStorage.addTestData();
+        var secondTestData = testDataStorage.addTestData();
+
+        firstTestData.getProject().setParentProject(secondTestData.getProject().getParentProject());
+
+        uncheckedWithSuperUser.getProjectRequest()
+                .create(firstTestData.getProject())
+                .then().assertThat().statusCode(HttpStatus.SC_BAD_REQUEST);
+    }
+
+    //8. create proj with existing name
+    @Test
+    public void projShouldNotGetCreatedHavingExistingName(){
+        var firstTestData = testDataStorage.addTestData();
+        var secondTestData = testDataStorage.addTestData();
+
+        var projectOne = checkedWithSuperUser.getProjectRequest()
+                .create(firstTestData.getProject());
+        testDataCleanUp.add(projectOne.getId());
+
+        secondTestData.getProject().setName(projectOne.getName());
+
+        uncheckedWithSuperUser.getProjectRequest()
+                .create(secondTestData.getProject())
+                .then().assertThat().statusCode(HttpStatus.SC_BAD_REQUEST)
+                .body(Matchers.containsString("Project with this name already exists: " + projectOne.getName()));
+    }
+
+    //9. create proj with existing id
+    @Test
+    public void projShouldNotGetCreatedHavingExistingId(){
+        var firstTestData = testDataStorage.addTestData();
+        var secondTestData = testDataStorage.addTestData();
+
+        var projectOne = checkedWithSuperUser.getProjectRequest()
+                .create(firstTestData.getProject());
+        testDataCleanUp.add(projectOne.getId());
+
+        secondTestData.getProject().setId(projectOne.getId());
+
+        uncheckedWithSuperUser.getProjectRequest()
+                .create(secondTestData.getProject())
+                .then().assertThat().statusCode(HttpStatus.SC_BAD_REQUEST)
+                .body(Matchers.containsString("Project ID \"" + projectOne.getId() + "\" is already used by another project"));
+    }
+
+    //10. create proj with name.length = 1 symbol
+    @Test
+    public void projShouldGetCreatedHaving1AlphaSymbolInName(){
+        var testData = testDataStorage.addTestData();
+
+        testData.getProject().setName(RandomStringUtils.randomAlphabetic(1));
+
+        var project = checkedWithSuperUser.getProjectRequest().create(testData.getProject());
+        testDataCleanUp.add(project.getId());
+
+        softly.assertThat(project.getName()).isEqualTo(testData.getProject().getName());
+    }
+
+    //11. create proj with name.length = 255 alphanumeric symbols
+    @Test
+    public void projShouldGetCreatedHaving255AlphaNumSymbolsInName(){
+        var testData = testDataStorage.addTestData();
+
+        testData.getProject().setName(RandomStringUtils.randomAlphanumeric(255));
+
+        var project = checkedWithSuperUser.getProjectRequest().create(testData.getProject());
+        testDataCleanUp.add(project.getId());
+
+        softly.assertThat(project.getName()).isEqualTo(testData.getProject().getName());
+    }
+
+    //12. create proj with name.length = 256 alphanumeric symbols
+    @Test
+    public void projShouldNotGetCreatedHaving256AlphaNumSymbolsInName(){
+        var testData = testDataStorage.addTestData();
+
+        testData.getProject().setName(RandomStringUtils.randomAlphanumeric(256));
+
+        uncheckedWithSuperUser.getProjectRequest().create(testData.getProject())
+                .then().assertThat()
+                .statusCode(HttpStatus.SC_BAD_REQUEST);
+    }
+
+}


### PR DESCRIPTION
This PR adds:
1. New tests for `/projects` and `/buildTypes` endpoints;
2.  Generic request generator for unchecked and checked requests - at this point this is only used in 1 tests as an example of the approach;
3. Basic support for deleting the created instances - this implementation is planned for further implevements.